### PR TITLE
通知機能の改善：メッセージ内容・重複・既読状態の修正

### DIFF
--- a/database/migrate-notifications.sql
+++ b/database/migrate-notifications.sql
@@ -1,0 +1,28 @@
+-- 既存のnotificationsテーブルにカラムを追加するマイグレーションSQL
+-- Supabaseで実行してください
+
+-- 1. 既存の通知データを削除（viewer_user_idが設定されていないため）
+TRUNCATE TABLE notifications;
+
+-- 2. 新しいカラムを追加
+ALTER TABLE notifications ADD COLUMN IF NOT EXISTS viewer_user_id INTEGER;
+ALTER TABLE notifications ADD COLUMN IF NOT EXISTS target_user_id INTEGER;
+ALTER TABLE notifications ADD COLUMN IF NOT EXISTS target_user_name VARCHAR(255);
+
+-- 3. NOT NULL制約を追加
+ALTER TABLE notifications ALTER COLUMN viewer_user_id SET NOT NULL;
+
+-- 4. 外部キー制約を追加
+ALTER TABLE notifications ADD CONSTRAINT fk_viewer_user
+FOREIGN KEY (viewer_user_id) REFERENCES users(id) ON DELETE CASCADE;
+
+ALTER TABLE notifications ADD CONSTRAINT fk_target_user
+FOREIGN KEY (target_user_id) REFERENCES users(id) ON DELETE CASCADE;
+
+-- 5. インデックスを追加
+CREATE INDEX IF NOT EXISTS idx_notifications_viewer
+ON notifications(viewer_user_id);
+
+-- 6. 重複防止用のユニーク制約を追加
+CREATE UNIQUE INDEX IF NOT EXISTS idx_notifications_unique
+ON notifications(type, actor_user_id, COALESCE(target_post_id, 0), viewer_user_id);

--- a/database/postgres-schema.sql
+++ b/database/postgres-schema.sql
@@ -66,10 +66,15 @@ CREATE TABLE IF NOT EXISTS notifications (
     type VARCHAR(50) NOT NULL,
     actor_user_id INTEGER NOT NULL,
     actor_user_name VARCHAR(255) NOT NULL,
+    viewer_user_id INTEGER NOT NULL,
+    target_user_id INTEGER,
+    target_user_name VARCHAR(255),
     target_applicant_id INTEGER NOT NULL,
     target_post_id INTEGER,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (actor_user_id) REFERENCES users(id) ON DELETE CASCADE,
+    FOREIGN KEY (viewer_user_id) REFERENCES users(id) ON DELETE CASCADE,
+    FOREIGN KEY (target_user_id) REFERENCES users(id) ON DELETE CASCADE,
     FOREIGN KEY (target_applicant_id) REFERENCES applicants(id) ON DELETE CASCADE,
     FOREIGN KEY (target_post_id) REFERENCES timeline_posts(id) ON DELETE CASCADE
 );
@@ -80,6 +85,13 @@ ON notifications(target_applicant_id);
 
 CREATE INDEX IF NOT EXISTS idx_notifications_actor
 ON notifications(actor_user_id);
+
+CREATE INDEX IF NOT EXISTS idx_notifications_viewer
+ON notifications(viewer_user_id);
+
+-- 重複防止用のユニーク制約（同じアクションに対して同じユーザーへの通知は1件のみ）
+CREATE UNIQUE INDEX IF NOT EXISTS idx_notifications_unique
+ON notifications(type, actor_user_id, COALESCE(target_post_id, 0), viewer_user_id);
 
 -- 初期ユーザーデータ挿入
 INSERT INTO users (username, password_hash, name) VALUES 

--- a/index.html
+++ b/index.html
@@ -1234,6 +1234,7 @@
                 .from('notifications')
                 .select('*')
                 .eq('target_applicant_id', applicantId)
+                .eq('viewer_user_id', currentUser.id)
                 .order('created_at', { ascending: false });
 
               if (error) {
@@ -1254,6 +1255,7 @@
               const { data, error } = await supabaseClient
                 .from('notifications')
                 .select('*')
+                .eq('viewer_user_id', currentUser.id)
                 .order('created_at', { ascending: false });
 
               if (error) {
@@ -1292,6 +1294,9 @@
                   type: 'post',
                   actor_user_id: currentUser.id,
                   actor_user_name: currentUser.name,
+                  viewer_user_id: user.id,
+                  target_user_id: null,
+                  target_user_name: null,
                   target_applicant_id: applicantId,
                   target_post_id: postId
                 }));
@@ -1302,10 +1307,10 @@
                   .from('notifications')
                   .insert(notifications);
 
-                if (insertError) {
+                if (insertError && !insertError.message?.includes('duplicate')) {
                   console.error('通知作成エラー:', insertError);
                 } else {
-                  console.log('投稿通知作成完了:', notifications.length + '件');
+                  console.log('投稿通知作成完了');
                 }
               } else {
                 console.log('通知対象ユーザーなし');
@@ -1320,7 +1325,7 @@
             try {
               console.log('返信通知作成開始:', { parentPostId, applicantId, replyId });
 
-              // 1. 返信先の投稿情報を取得（元投稿IDの特定のため）
+              // 1. 返信先の投稿情報を取得
               const { data: parentPost, error: parentError } = await supabaseClient
                 .from('timeline_posts')
                 .select('id, author, parent_post_id')
@@ -1334,18 +1339,18 @@
 
               console.log('返信先の投稿:', parentPost);
 
-              // 2. 元投稿（ルート投稿）のIDを特定
+              // 2. 元投稿（ルート投稿）のIDと作成者を特定
               let rootPostId = parentPostId;
+              let rootPostAuthor = parentPost.author;
 
               // parent_post_idがnullでない場合、さらに遡って元投稿を探す
               if (parentPost.parent_post_id) {
-                // 再帰的に元投稿を探す
                 let currentPost = parentPost;
 
                 while (currentPost.parent_post_id) {
                   const { data: ancestorPost, error: ancestorError } = await supabaseClient
                     .from('timeline_posts')
-                    .select('id, parent_post_id')
+                    .select('id, author, parent_post_id')
                     .eq('id', currentPost.parent_post_id)
                     .single();
 
@@ -1353,12 +1358,24 @@
 
                   currentPost = ancestorPost;
                   rootPostId = ancestorPost.id;
+                  rootPostAuthor = ancestorPost.author;
                 }
               }
 
-              console.log('元投稿ID:', rootPostId);
+              console.log('元投稿ID:', rootPostId, '元投稿作成者:', rootPostAuthor);
 
-              // 3. 全ユーザーを取得
+              // 3. 返信先の投稿者のユーザー情報を取得
+              const { data: targetUser, error: targetUserError } = await supabaseClient
+                .from('users')
+                .select('id, name')
+                .eq('name', parentPost.author)
+                .single();
+
+              if (targetUserError) {
+                console.error('返信先ユーザー取得エラー:', targetUserError);
+              }
+
+              // 4. 全ユーザーを取得
               const { data: allUsers, error: usersError } = await supabaseClient
                 .from('users')
                 .select('id, name');
@@ -1369,34 +1386,35 @@
               }
 
               console.log('通知対象ユーザー（全ユーザー）:', allUsers);
-              console.log('現在のユーザーID:', currentUser.id);
 
-              // 4. 自分以外の全ユーザーに通知を作成
+              // 5. 自分以外の全ユーザーに通知を作成
               const notifications = allUsers
-                .filter(user => user.id !== currentUser.id) // 自分自身は除外
+                .filter(user => user.id !== currentUser.id)
                 .map(user => ({
                   type: 'reply',
                   actor_user_id: currentUser.id,
                   actor_user_name: currentUser.name,
+                  viewer_user_id: user.id,
+                  target_user_id: targetUser?.id || null,
+                  target_user_name: targetUser?.name || parentPost.author,
                   target_applicant_id: applicantId,
-                  target_post_id: rootPostId, // 元投稿のIDを指定
+                  target_post_id: replyId, // 返信自体のIDを設定
                   created_at: new Date().toISOString()
                 }));
 
               console.log('作成する通知:', notifications);
 
               if (notifications.length > 0) {
+                // 重複を無視して挿入（ユニーク制約でエラーになる場合はスキップ）
                 const { error: notifError } = await supabaseClient
                   .from('notifications')
                   .insert(notifications);
 
-                if (notifError) {
+                if (notifError && !notifError.message?.includes('duplicate')) {
                   console.error('返信通知作成エラー:', notifError);
                 } else {
-                  console.log('返信通知を作成しました:', notifications.length + '件');
+                  console.log('返信通知を作成しました');
                 }
-              } else {
-                console.log('通知対象ユーザーがいません（自分のみ）');
               }
 
             } catch (error) {
@@ -1408,6 +1426,17 @@
           const createHeartNotifications = async (applicantId, postId, post) => {
             try {
               console.log('いいね通知作成開始:', { applicantId, postId, post });
+
+              // 投稿者のユーザー情報を取得
+              const { data: targetUser, error: targetUserError } = await supabaseClient
+                .from('users')
+                .select('id, name')
+                .eq('name', post.author)
+                .single();
+
+              if (targetUserError) {
+                console.error('投稿者ユーザー取得エラー:', targetUserError);
+              }
 
               // 全ユーザーを取得
               const { data: allUsers, error: usersError } = await supabaseClient
@@ -1423,11 +1452,14 @@
 
               // 自分以外の全ユーザーに通知を作成
               const notifications = allUsers
-                .filter(user => user.id !== currentUser.id) // 自分自身は除外
+                .filter(user => user.id !== currentUser.id)
                 .map(user => ({
                   type: 'heart',
                   actor_user_id: currentUser.id,
                   actor_user_name: currentUser.name,
+                  viewer_user_id: user.id,
+                  target_user_id: targetUser?.id || null,
+                  target_user_name: targetUser?.name || post.author,
                   target_applicant_id: applicantId,
                   target_post_id: postId
                 }));
@@ -1439,20 +1471,18 @@
                   .from('notifications')
                   .insert(notifications);
 
-                if (insertError) {
+                if (insertError && !insertError.message?.includes('duplicate')) {
                   console.error('いいね通知作成エラー:', insertError);
                 } else {
-                  console.log('いいね通知作成完了:', notifications.length + '件');
+                  console.log('いいね通知作成完了');
                 }
-              } else {
-                console.log('通知対象ユーザーがいません（自分のみ）');
               }
             } catch (error) {
               console.error('いいね通知作成処理エラー:', error);
             }
           };
 
-          // 通知をクリックした際に通知を削除
+          // 通知をクリックした際に通知を削除（自分の通知のみ）
           const deleteNotification = async (notificationId) => {
             try {
               console.log('通知削除開始:', notificationId);
@@ -1460,7 +1490,8 @@
               const { error } = await supabaseClient
                 .from('notifications')
                 .delete()
-                .eq('id', notificationId);
+                .eq('id', notificationId)
+                .eq('viewer_user_id', currentUser.id);
 
               if (error) {
                 console.error('通知削除エラー:', error);
@@ -2486,9 +2517,19 @@
                               if (notif.type === 'post') {
                                 message = `${notif.actor_user_name}さんが新しい投稿をしました`;
                               } else if (notif.type === 'reply') {
-                                message = `${notif.actor_user_name}さんがあなたの投稿に返信しました`;
+                                // 返信対象が自分かどうかで文言を変更
+                                if (notif.target_user_id === currentUser.id) {
+                                  message = `${notif.actor_user_name}さんがあなたに返信しました`;
+                                } else {
+                                  message = `${notif.actor_user_name}さんが${notif.target_user_name}さんに返信しました`;
+                                }
                               } else if (notif.type === 'heart') {
-                                message = `${notif.actor_user_name}さんがあなたの投稿にいいねしました`;
+                                // いいね対象が自分かどうかで文言を変更
+                                if (notif.target_user_id === currentUser.id) {
+                                  message = `${notif.actor_user_name}さんがあなたの投稿にいいねしました`;
+                                } else {
+                                  message = `${notif.actor_user_name}さんが${notif.target_user_name}さんの投稿にいいねしました`;
+                                }
                               }
 
                               return (


### PR DESCRIPTION
【修正内容】

① 通知メッセージ内容の改善
- 返信対象が自分の場合：「〇〇さんがあなたに返信しました」
- 返信対象が他のユーザーの場合：「〇〇さんが△△さんに返信しました」
- いいねも同様に、対象者によって自然な日本語メッセージを表示

② 通知の重複修正
- データベースにユニーク制約を追加（type, actor_user_id, target_post_id, viewer_user_id）
- 同じアクションに対して同じユーザーへの通知は1件のみ
- 重複エラーは無視して処理を継続

③ 通知の既読状態の不具合修正
- viewer_user_idカラムを追加し、受信者を明示的に管理
- target_user_id, target_user_nameカラムを追加し、対象者情報を保存
- 通知取得・削除時にviewer_user_id = currentUser.idで自分の通知のみを操作
- 他のユーザーが通知を閲覧しても、自分の通知は影響を受けない

【変更ファイル】
- database/postgres-schema.sql: notificationsテーブルにviewer_user_id, target_user_id, target_user_nameカラムを追加
- database/migrate-notifications.sql: 既存データベースのマイグレーション用SQL（新規作成）
- index.html: 通知作成・取得・削除・表示ロジックを全面的に修正

【注意事項】
- Supabaseで database/migrate-notifications.sql を実行してデータベースを更新してください
- 既存の通知データは削除されます（マイグレーション時にTRUNCATEを実行）

🤖 Generated with [Claude Code](https://claude.com/claude-code)