### PR TITLE
NEWバッジ表示の実装：lastViewedAtベースの閲覧履歴管理

### DIFF
--- a/database/migrate-notifications.sql
+++ b/database/migrate-notifications.sql
@@ -30,3 +30,20 @@ ON notifications(is_read);
 -- 6. 重複防止用のユニーク制約を追加
 CREATE UNIQUE INDEX IF NOT EXISTS idx_notifications_unique
 ON notifications(type, actor_user_id, COALESCE(target_post_id, 0), viewer_user_id);
+
+-- 7. ユーザー別申込者閲覧履歴テーブルを作成
+CREATE TABLE IF NOT EXISTS user_applicant_views (
+    id SERIAL PRIMARY KEY,
+    user_id INTEGER NOT NULL,
+    applicant_id INTEGER NOT NULL,
+    last_viewed_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+    FOREIGN KEY (applicant_id) REFERENCES applicants(id) ON DELETE CASCADE,
+    UNIQUE(user_id, applicant_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_applicant_views_user
+ON user_applicant_views(user_id);
+
+CREATE INDEX IF NOT EXISTS idx_user_applicant_views_applicant
+ON user_applicant_views(applicant_id);

--- a/database/postgres-schema.sql
+++ b/database/postgres-schema.sql
@@ -94,6 +94,23 @@ ON notifications(viewer_user_id);
 CREATE UNIQUE INDEX IF NOT EXISTS idx_notifications_unique
 ON notifications(type, actor_user_id, COALESCE(target_post_id, 0), viewer_user_id);
 
+-- ユーザー別申込者閲覧履歴テーブル
+CREATE TABLE IF NOT EXISTS user_applicant_views (
+    id SERIAL PRIMARY KEY,
+    user_id INTEGER NOT NULL,
+    applicant_id INTEGER NOT NULL,
+    last_viewed_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+    FOREIGN KEY (applicant_id) REFERENCES applicants(id) ON DELETE CASCADE,
+    UNIQUE(user_id, applicant_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_applicant_views_user
+ON user_applicant_views(user_id);
+
+CREATE INDEX IF NOT EXISTS idx_user_applicant_views_applicant
+ON user_applicant_views(applicant_id);
+
 -- 初期ユーザーデータ挿入
 INSERT INTO users (username, password_hash, name) VALUES 
 ('a', '$2a$10$rQQqGqjMZJvPm5f5yP.rSe8QmN3LYx4wGF5M8wHrJ3FrKvE2qzNmy', '藤堂　友未枝'),

--- a/index.html
+++ b/index.html
@@ -1092,6 +1092,9 @@
           const [notifications, setNotifications] = React.useState([]);
           const [allNotifications, setAllNotifications] = React.useState([]);
 
+          // 申込者閲覧履歴管理
+          const [applicantViews, setApplicantViews] = React.useState({});
+
           const [editingPostId, setEditingPostId] = React.useState(null);
           const [editingContent, setEditingContent] = React.useState('');
           const [deletingPostId, setDeletingPostId] = React.useState(null);
@@ -1219,6 +1222,66 @@
               setApplicants(data);
             } catch (error) {
               console.error('Failed to load applicants:', error);
+            }
+          };
+
+          // 申込者の閲覧履歴を取得
+          const loadApplicantViews = async () => {
+            try {
+              if (!currentUser) return;
+
+              const { data, error } = await supabaseClient
+                .from('user_applicant_views')
+                .select('applicant_id, last_viewed_at')
+                .eq('user_id', currentUser.id);
+
+              if (error) {
+                console.error('閲覧履歴取得エラー:', error);
+                return;
+              }
+
+              // applicant_idをキーとしたオブジェクトに変換
+              const viewsMap = {};
+              data.forEach(view => {
+                viewsMap[view.applicant_id] = view.last_viewed_at;
+              });
+
+              setApplicantViews(viewsMap);
+              console.log('閲覧履歴を取得しました:', viewsMap);
+            } catch (error) {
+              console.error('閲覧履歴取得処理エラー:', error);
+            }
+          };
+
+          // 申込者の閲覧時刻を更新
+          const updateApplicantView = async (applicantId) => {
+            try {
+              if (!currentUser) return;
+
+              const { error } = await supabaseClient
+                .from('user_applicant_views')
+                .upsert({
+                  user_id: currentUser.id,
+                  applicant_id: applicantId,
+                  last_viewed_at: new Date().toISOString()
+                }, {
+                  onConflict: 'user_id,applicant_id'
+                });
+
+              if (error) {
+                console.error('閲覧時刻更新エラー:', error);
+                return;
+              }
+
+              console.log('閲覧時刻を更新しました:', applicantId);
+
+              // ローカル状態も更新
+              setApplicantViews(prev => ({
+                ...prev,
+                [applicantId]: new Date().toISOString()
+              }));
+            } catch (error) {
+              console.error('閲覧時刻更新処理エラー:', error);
             }
           };
 
@@ -1554,6 +1617,7 @@
               setLoginForm({ id: '', password: '' });
               await loadApplicants();
               await fetchAllNotifications();
+              await loadApplicantViews();
               console.log('ログイン成功:', { id: response.user.id, name: response.user.name });
             } catch (error) {
               console.error('Login failed:', error);
@@ -2536,7 +2600,7 @@
                               color: '#0066cc',
                               marginBottom: '8px'
                             }}>
-                              📬 新しい通知 ({notifications.length})
+                              新しい通知 ({notifications.length})
                             </div>
                             {notifications.map(notif => {
                               let message = '';
@@ -3024,9 +3088,15 @@
                     </thead>
                     <tbody>
                       {sortedApplicants.map((applicant) => {
-                        // この申込者に関する未読通知があるか確認
-                        const hasUnreadNotifications = allNotifications.some(
-                          n => n.target_applicant_id === applicant.id && !n.is_read
+                        // この申込者に新しい動きがあるかチェック（lastViewedAtベース）
+                        const lastViewedAt = applicantViews[applicant.id];
+                        const hasNewActivity = applicant.timeline && applicant.timeline.length > 0 && (
+                          !lastViewedAt ||
+                          applicant.timeline.some(post => {
+                            const postTime = new Date(post.timestamp || post.created_at).getTime();
+                            const viewedTime = new Date(lastViewedAt).getTime();
+                            return postTime > viewedTime;
+                          })
                         );
 
                         return (
@@ -3035,6 +3105,9 @@
                           onClick={async () => {
                             setSelectedApplicant(applicant);
                             setCurrentView('detail');
+
+                            // この申込者の閲覧時刻を更新
+                            await updateApplicantView(applicant.id);
 
                             // この申込者に関する未読通知を既読にする
                             await markNotificationsAsRead(applicant.id);
@@ -3045,11 +3118,12 @@
                           <td>{applicant.applicationDate}</td>
                           <td style={{fontWeight: '500', color: '#2c3e50', position: 'relative'}}>
                             {applicant.name}
-                            {hasUnreadNotifications && (
+                            {hasNewActivity && (
                               <span style={{
-                                marginLeft: '8px',
+                                display: 'inline-block',
+                                marginLeft: '6px',
                                 backgroundColor: '#dc3545',
-                                color: '#fff',
+                                color: '#ffffff',
                                 fontSize: '10px',
                                 fontWeight: '600',
                                 padding: '2px 6px',


### PR DESCRIPTION
【修正内容】

① 📬絵文字の削除
- 通知エリアのタイトルから📬絵文字を削除
- シンプルで業務的な見た目に変更

② user_applicant_viewsテーブルの作成
- ユーザーごとの申込者閲覧履歴を管理するテーブルを追加
- カラム: user_id, applicant_id, last_viewed_at
- UNIQUE制約でユーザーと申込者の組み合わせを一意に管理

③ 閲覧履歴管理機能の実装
- loadApplicantViews(): ログイン時に閲覧履歴を取得
- updateApplicantView(): 申込者をクリック時に閲覧時刻を更新
- applicantViewsステートで閲覧履歴を管理

④ NEWバッジ表示条件の変更
- is_readフラグベース → lastViewedAtベースに変更
- タイムライン最新投稿のtimestampがlast_viewed_atより新しい場合に表示
- 申込者を開いた時点で閲覧時刻が更新され、NEWバッジが消える
- ユーザーごとに独立して管理

⑤ デザインの調整
- display: inline-blockを明示的に指定
- marginLeft: 6pxに統一

【動作】
1. 他ユーザーが投稿・返信・いいねを行うと、未閲覧の申込者にNEWバッジが表示
2. 申込者を選択すると閲覧時刻が更新され、NEWバッジが消える
3. 他のユーザーの閲覧状況には影響しない
4. リロード後も閲覧履歴が保持される（Supabaseで管理）

【変更ファイル】
- database/postgres-schema.sql: user_applicant_viewsテーブルを追加
- database/migrate-notifications.sql: マイグレーションSQLを更新
- index.html: 閲覧履歴管理とNEWバッジ表示ロジックを実装

🤖 Generated with [Claude Code](https://claude.com/claude-code)