### PR TITLE
いいね重複エラーとNEWバッジ表示問題を修正

### DIFF
--- a/database/init-last-updated.sql
+++ b/database/init-last-updated.sql
@@ -1,0 +1,25 @@
+-- 既存の申込者データのlast_updated_byとlast_updated_atを初期化
+-- 各申込者の最新のタイムライン投稿から情報を取得して設定
+
+UPDATE applicants
+SET
+  last_updated_by = (
+    SELECT author
+    FROM timeline_posts
+    WHERE timeline_posts.applicant_id = applicants.id
+    ORDER BY created_at DESC
+    LIMIT 1
+  ),
+  last_updated_at = (
+    SELECT created_at
+    FROM timeline_posts
+    WHERE timeline_posts.applicant_id = applicants.id
+    ORDER BY created_at DESC
+    LIMIT 1
+  )
+WHERE last_updated_by IS NULL
+  AND EXISTS (
+    SELECT 1
+    FROM timeline_posts
+    WHERE timeline_posts.applicant_id = applicants.id
+  );

--- a/index.html
+++ b/index.html
@@ -1285,6 +1285,62 @@
             }
           };
 
+          // いいね状態を読み込む（特定の申込者用）
+          const loadLikesForApplicant = async (applicantId) => {
+            try {
+              if (!applicantId) {
+                return;
+              }
+
+              // この申込者のタイムライン投稿IDを取得
+              const { data: posts, error: postsError } = await supabaseClient
+                .from('timeline_posts')
+                .select('id')
+                .eq('applicant_id', applicantId);
+
+              if (postsError) {
+                console.error('投稿ID取得エラー:', postsError);
+                return;
+              }
+
+              if (!posts || posts.length === 0) {
+                return;
+              }
+
+              const postIds = posts.map(p => p.id);
+
+              // この申込者の投稿に対する現在のユーザーのいいねを取得
+              const { data: userLikes, error: likesError } = await supabaseClient
+                .from('likes')
+                .select('post_id')
+                .eq('user_id', currentUser.id)
+                .in('post_id', postIds);
+
+              if (likesError) {
+                console.error('いいね状態取得エラー:', likesError);
+                return;
+              }
+
+              // いいね状態を更新
+              const newLikes = {};
+              if (userLikes) {
+                userLikes.forEach(like => {
+                  const key = `${applicantId}-${like.post_id}`;
+                  newLikes[key] = true;
+                });
+              }
+
+              setLikes(prev => ({
+                ...prev,
+                ...newLikes
+              }));
+
+              console.log('いいね状態を読み込みました:', newLikes);
+            } catch (error) {
+              console.error('いいね状態読み込みエラー:', error);
+            }
+          };
+
           // 通知を取得（特定の申込者用）
           const fetchNotifications = async (applicantId) => {
             try {
@@ -3113,6 +3169,9 @@
                           onClick={async () => {
                             setSelectedApplicant(applicant);
                             setCurrentView('detail');
+
+                            // この申込者のいいね状態を読み込む
+                            await loadLikesForApplicant(applicant.id);
 
                             // この申込者の閲覧時刻を更新
                             await updateApplicantView(applicant.id);


### PR DESCRIPTION
【修正内容】
1. いいね重複エラーの修正
   - loadLikesForApplicant関数を追加
   - 申込者選択時にいいね状態を読み込む処理を追加
   - 既存のいいねをチェックしてから新規いいねを追加

2. NEWバッジ表示問題の修正
   - init-last-updated.sqlを作成
   - 既存申込者データのlast_updated_by/last_updated_atを初期化
   - 最新のタイムライン投稿から情報を取得

🤖 Generated with [Claude Code](https://claude.com/claude-code)