### PR TITLE
タイムライン投稿にstatusカラムを追加し、ステータス連動を改善

### DIFF
--- a/database/add-timeline-status.sql
+++ b/database/add-timeline-status.sql
@@ -1,0 +1,36 @@
+-- timeline_postsテーブルにstatusカラムを追加
+-- これにより、各投稿にステータスを保存できるようになります
+
+BEGIN;
+
+-- statusカラムを追加
+ALTER TABLE timeline_posts ADD COLUMN IF NOT EXISTS status VARCHAR(100);
+
+-- インデックスを追加（パフォーマンス向上のため）
+CREATE INDEX IF NOT EXISTS idx_timeline_posts_status
+ON timeline_posts(status);
+
+CREATE INDEX IF NOT EXISTS idx_timeline_posts_applicant_created
+ON timeline_posts(applicant_id, created_at DESC);
+
+-- 既存データのstatusを初期化（actionからstatusをマッピング）
+UPDATE timeline_posts
+SET status = CASE action
+  WHEN '申込書受領' THEN '申込書受領'
+  WHEN '実調日程調整中' THEN '実調日程調整中'
+  WHEN '実調完了' THEN '実調完了'
+  WHEN '健康診断書依頼' THEN '健康診断書待ち'
+  WHEN '健康診断書受領' THEN '健康診断書受領'
+  WHEN '判定会議中' THEN '判定会議中'
+  WHEN '入居決定' THEN '入居決定'
+  WHEN '入居不可' THEN '入居不可'
+  WHEN '入居日調整中' THEN '入居日調整中'
+  WHEN '書類送付済' THEN '書類送付済'
+  WHEN '入居準備完了' THEN '入居準備完了'
+  WHEN '入居完了' THEN '入居完了'
+  WHEN 'キャンセル' THEN 'キャンセル'
+  ELSE NULL
+END
+WHERE action IS NOT NULL;
+
+COMMIT;

--- a/database/postgres-schema.sql
+++ b/database/postgres-schema.sql
@@ -40,6 +40,7 @@ CREATE TABLE IF NOT EXISTS timeline_posts (
     author VARCHAR(255) NOT NULL,
     content TEXT NOT NULL,
     action VARCHAR(100),
+    status VARCHAR(100),
     parent_post_id INTEGER NULL,
     post_date DATE DEFAULT CURRENT_DATE,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
@@ -50,6 +51,7 @@ CREATE TABLE IF NOT EXISTS timeline_posts (
 
 -- 既存データ保護のため、カラムが存在しない場合のみ追加
 ALTER TABLE timeline_posts ADD COLUMN IF NOT EXISTS post_date DATE DEFAULT CURRENT_DATE;
+ALTER TABLE timeline_posts ADD COLUMN IF NOT EXISTS status VARCHAR(100);
 
 -- いいねテーブル
 CREATE TABLE IF NOT EXISTS likes (


### PR DESCRIPTION
【問題】
- 投稿作成・削除時にステータスが正しく更新されない
- ログイン後にステータスが古い状態に戻る
- 投稿削除時にステータスが元に戻らない

【修正内容】
1. timeline_postsテーブルにstatusカラムを追加
   - 各投稿にステータスを保存するように変更
   - actionからstatusへのマッピングを実装

2. 投稿作成時の処理を改善
   - timeline_postsにstatusを保存
   - applicants.statusも同時に更新

3. 投稿削除時の処理を追加
   - 削除後、最新のstatus付き投稿を検索
   - 申込者のstatusを最新投稿のstatusに更新
   - statusのある投稿がない場合はstatusをクリア

4. データベーススキーマを更新
   - statusカラムとインデックスを追加

【実現すること】
- 投稿作成時 → 最新投稿のステータスが即座に反映
- 投稿削除時 → 一つ前の投稿のステータスに戻る
- ログイン後も最新のステータスが正しく表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)