### PR TITLE
KP情報に続柄を含めて表示するように修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -2627,7 +2627,7 @@
                     </div>
                     <div className="info-section">
                       <h3>KP情報</h3>
-                      {selectedApplicant.kp && <div className="info-item">{selectedApplicant.kp}</div>}
+                      {selectedApplicant.kp && <div className="info-item">{selectedApplicant.kp}{selectedApplicant.kpRelationship && `（${selectedApplicant.kpRelationship}）`}</div>}
                       {selectedApplicant.kpContact && <div className="info-item">連絡先: {selectedApplicant.kpContact}</div>}
                       {selectedApplicant.kpAddress && <div className="info-item">住所: {selectedApplicant.kpAddress}</div>}
                     </div>


### PR DESCRIPTION
- index.html: KP情報表示部分に続柄を括弧付きで追加
  - 表示例：「いわさき きよみ（長女）」
  - 続柄が空の場合は括弧なしで「いわさき きよみ」のみ表示

この変更により：
- メイン画面（詳細画面）でKP名と続柄が両方表示される
- 続柄が未入力でもエラーや空括弧が出ない
- UIデザイン・レイアウトは変更なし
- データベース構造は変更なし（既存カラムを利用）

🤖 Generated with [Claude Code](https://claude.com/claude-code)