### PR TITLE
NEWバッジのリアルタイム反映を改善

### DIFF
--- a/index.html
+++ b/index.html
@@ -1182,6 +1182,14 @@
                 async (payload) => {
                   // 申込者リストを再取得
                   await loadApplicants();
+
+                  // 全通知を再取得してNEWバッジを即時更新
+                  await fetchAllNotifications();
+
+                  // 現在選択中の申込者の通知も再取得
+                  if (selectedApplicant) {
+                    await fetchNotifications(selectedApplicant.id);
+                  }
                 }
               )
               .subscribe();
@@ -1192,8 +1200,13 @@
               .on('postgres_changes',
                 { event: '*', schema: 'public', table: 'likes' },
                 async (payload) => {
-                  // いいね状態を更新（簡易実装：該当投稿のいいね状態を再取得）
-                  // より詳細な実装が必要な場合はここで処理
+                  // 全通知を再取得してNEWバッジを即時更新
+                  await fetchAllNotifications();
+
+                  // いいね状態を再読み込み（現在選択中の申込者のみ）
+                  if (selectedApplicant) {
+                    await loadLikesForApplicant(selectedApplicant.id);
+                  }
                 }
               )
               .subscribe();


### PR DESCRIPTION
問題：
- 他ユーザーがいいね・投稿・返信をしても、NEWバッジが即座に表示されない
- ページ遷移するまでNEWバッジが反映されない

原因：
- timeline_postsテーブルの監視でfetchAllNotifications()を呼んでいなかった
- likesテーブルの監視で何も処理していなかった

修正内容：
1. timeline_posts監視：loadApplicants()に加えて以下を追加
   - fetchAllNotifications()を呼び出してNEWバッジを即時更新
   - 詳細画面の通知も再取得

2. likes監視：空実装から以下を追加
   - fetchAllNotifications()を呼び出してNEWバッジを即時更新
   - 選択中申込者のいいね状態を再読み込み

これにより：
- ユーザーAが投稿・返信・いいねをすると即座に他ユーザー（2名）の画面でNEWバッジが表示される
- ページ遷移やリロード不要でリアルタイム反映される
- 通知テーブル、投稿テーブル、いいねテーブルすべての変更を監視

🤖 Generated with [Claude Code](https://claude.com/claude-code)