### PR TITLE
NEWバッジの表示問題を修正：applicantsテーブルのリアルタイム監視を追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -1212,11 +1212,27 @@
               )
               .subscribe();
 
+            // 申込者テーブルの変更を監視（last_updated_byの変更を検知）
+            const applicantsSubscription = supabaseClient
+              .channel('applicants-changes')
+              .on('postgres_changes',
+                { event: 'UPDATE', schema: 'public', table: 'applicants' },
+                async (payload) => {
+                  // 申込者リストを再取得
+                  await loadApplicants();
+
+                  // 全通知を再取得してNEWバッジを即時更新
+                  await fetchAllNotifications();
+                }
+              )
+              .subscribe();
+
             // クリーンアップ関数（コンポーネントアンマウント時にリアルタイム監視を停止）
             return () => {
               supabaseClient.removeChannel(notificationsSubscription);
               supabaseClient.removeChannel(postsSubscription);
               supabaseClient.removeChannel(likesSubscription);
+              supabaseClient.removeChannel(applicantsSubscription);
             };
           }, [isLoggedIn, currentUser, selectedApplicant]);
 


### PR DESCRIPTION
問題：
- 他ユーザーが投稿・返信・いいねをしても、NEWバッジが表示されない
- 通知自体はDBに作成されていたが、UIに反映されなかった

原因：
- applicantsテーブルの変更（last_updated_by更新）を監視する リアルタイムサブスクリプションが不足していた
- notifications/posts/likesテーブルは監視していたが、 applicantsテーブルの監視がなかった

修正内容：
- applicantsテーブルのUPDATEイベントを監視する リアルタイムサブスクリプションを追加
- テーブル更新時にloadApplicants()とfetchAllNotifications()を実行
- これにより、他ユーザーのアクションが即座にNEWバッジとして反映される

🤖 Generated with [Claude Code](https://claude.com/claude-code)