### PR TITLE
入居申込目録機能の統合: 新フィールド追加と統計API実装

### DIFF
--- a/api-client.js
+++ b/api-client.js
@@ -120,6 +120,10 @@ class APIClient {
           cm_contact: options.body.cmContact,
           assignee: options.body.assignee,
           notes: options.body.notes,
+          gender: options.body.gender,
+          room_number: options.body.roomNumber,
+          move_in_date: options.body.moveInDate,
+          municipality: null, // サーバー側で自動計算
           status: '申込書受領',
           timeline: []
         };
@@ -150,7 +154,11 @@ class APIClient {
             care_manager_name: options.body.careManagerName,
             cm_contact: options.body.cmContact,
             assignee: options.body.assignee,
-            notes: options.body.notes
+            notes: options.body.notes,
+            gender: options.body.gender,
+            room_number: options.body.roomNumber,
+            move_in_date: options.body.moveInDate,
+            municipality: null // サーバー側で自動計算
           };
           saveLocalData(data);
           return { message: '申込者情報が更新されました' };
@@ -269,6 +277,11 @@ class APIClient {
     return await this.request(`/applicants/${applicantId}/posts/${postId}`, {
       method: 'DELETE',
     });
+  }
+
+  // 統計データ取得
+  async getStatistics() {
+    return await this.request('/statistics');
   }
 
   // WebSocket関連

--- a/database/migration-add-registry-fields.sql
+++ b/database/migration-add-registry-fields.sql
@@ -1,0 +1,7 @@
+-- 入居申込目録機能のための追加フィールド
+-- 性別、部屋番号、入居日、市区町村を追加
+
+ALTER TABLE applicants ADD COLUMN gender TEXT;
+ALTER TABLE applicants ADD COLUMN room_number TEXT;
+ALTER TABLE applicants ADD COLUMN move_in_date DATE;
+ALTER TABLE applicants ADD COLUMN municipality TEXT;

--- a/database/postgres-migration-add-registry-fields.sql
+++ b/database/postgres-migration-add-registry-fields.sql
@@ -1,0 +1,7 @@
+-- 入居申込目録機能のための追加フィールド (PostgreSQL版)
+-- 性別、部屋番号、入居日、市区町村を追加
+
+ALTER TABLE applicants ADD COLUMN IF NOT EXISTS gender VARCHAR(10);
+ALTER TABLE applicants ADD COLUMN IF NOT EXISTS room_number VARCHAR(50);
+ALTER TABLE applicants ADD COLUMN IF NOT EXISTS move_in_date DATE;
+ALTER TABLE applicants ADD COLUMN IF NOT EXISTS municipality VARCHAR(100);

--- a/index.html
+++ b/index.html
@@ -1130,7 +1130,10 @@
             cmContact: '',
             assignee: '',
             notes: '',
-            applicationDate: ''
+            applicationDate: '',
+            gender: '',
+            roomNumber: '',
+            moveInDate: ''
           });
 
           const users = {
@@ -1931,7 +1934,10 @@
               cmContact: applicant.cmContact,
               assignee: applicant.assignee,
               notes: applicant.notes || '',
-              applicationDate: applicant.applicationDate || ''
+              applicationDate: applicant.applicationDate || '',
+              gender: applicant.gender || '',
+              roomNumber: applicant.roomNumber || '',
+              moveInDate: applicant.moveInDate || ''
             });
             setShowEditModal(true);
           };
@@ -1973,7 +1979,10 @@
                 cmContact: formData.cmContact,
                 assignee: formData.assignee,
                 notes: formData.notes,
-                applicationDate: formData.applicationDate
+                applicationDate: formData.applicationDate,
+                gender: formData.gender,
+                roomNumber: formData.roomNumber,
+                moveInDate: formData.moveInDate
               };
 
               await apiClient.updateApplicant(editingApplicant.id, applicantData);
@@ -1994,7 +2003,10 @@
                 cmContact: '',
                 assignee: '',
                 notes: '',
-                applicationDate: ''
+                applicationDate: '',
+                gender: '',
+                roomNumber: '',
+                moveInDate: ''
               });
               setEditingApplicant(null);
               setShowEditModal(false);
@@ -2042,6 +2054,9 @@
                 kpRelationship: formData.kpRelationship,
                 kpContact: formData.kpContact,
                 kpAddress: formData.kpAddress,
+                gender: formData.gender,
+                roomNumber: formData.roomNumber,
+                moveInDate: formData.moveInDate,
                 careManager: formData.careManager,
                 careManagerName: formData.careManagerName,
                 cmContact: formData.cmContact,
@@ -2068,7 +2083,10 @@
                 cmContact: '',
                 assignee: '',
                 notes: '',
-                applicationDate: ''
+                applicationDate: '',
+                gender: '',
+                roomNumber: '',
+                moveInDate: ''
               });
               setShowModal(false);
             } catch (error) {
@@ -2764,8 +2782,12 @@
                     <div className="info-section">
                       <h3>基本情報</h3>
                       <div className="info-item">申込日: {selectedApplicant.applicationDate}</div>
+                      {selectedApplicant.moveInDate && <div className="info-item">入居日: {selectedApplicant.moveInDate}</div>}
+                      {selectedApplicant.gender && <div className="info-item">性別: {selectedApplicant.gender}</div>}
+                      {selectedApplicant.roomNumber && <div className="info-item">部屋番号: {selectedApplicant.roomNumber}</div>}
                       {selectedApplicant.assignee && <div className="info-item">担当者: {selectedApplicant.assignee}</div>}
                       {selectedApplicant.address && <div className="info-item">住所: {selectedApplicant.address}</div>}
+                      {selectedApplicant.municipality && <div className="info-item">市区町村: {selectedApplicant.municipality}</div>}
                     </div>
                     <div className="info-section">
                       <h3>KP情報</h3>
@@ -3531,6 +3553,31 @@
                             </select>
                           </div>
                         </div>
+                        <div className="form-row">
+                          <div className="form-group">
+                            <label className="form-label">性別</label>
+                            <select
+                              name="gender"
+                              value={formData.gender}
+                              onChange={handleInputChange}
+                              className="form-input"
+                            >
+                              <option value="">選択してください</option>
+                              <option value="男">男</option>
+                              <option value="女">女</option>
+                            </select>
+                          </div>
+                          <div className="form-group">
+                            <label className="form-label">部屋番号</label>
+                            <input
+                              type="text"
+                              name="roomNumber"
+                              value={formData.roomNumber}
+                              onChange={handleInputChange}
+                              className="form-input"
+                            />
+                          </div>
+                        </div>
                         <div className="form-group">
                           <label className="form-label">住所</label>
                           <input
@@ -3650,16 +3697,28 @@
                             placeholder="特記事項やメモを入力してください..."
                           />
                         </div>
-                        <div className="form-group">
-                          <label className="form-label">申込日 *</label>
-                          <input
-                            type="date"
-                            name="applicationDate"
-                            value={formData.applicationDate}
-                            onChange={handleInputChange}
-                            className="form-input"
-                            required
-                          />
+                        <div className="form-row">
+                          <div className="form-group">
+                            <label className="form-label">申込日 *</label>
+                            <input
+                              type="date"
+                              name="applicationDate"
+                              value={formData.applicationDate}
+                              onChange={handleInputChange}
+                              className="form-input"
+                              required
+                            />
+                          </div>
+                          <div className="form-group">
+                            <label className="form-label">入居日</label>
+                            <input
+                              type="date"
+                              name="moveInDate"
+                              value={formData.moveInDate}
+                              onChange={handleInputChange}
+                              className="form-input"
+                            />
+                          </div>
                         </div>
                       </form>
                     </div>
@@ -3740,6 +3799,31 @@
                             </select>
                           </div>
                         </div>
+                        <div className="form-row">
+                          <div className="form-group">
+                            <label className="form-label">性別</label>
+                            <select
+                              name="gender"
+                              value={formData.gender}
+                              onChange={handleInputChange}
+                              className="form-input"
+                            >
+                              <option value="">選択してください</option>
+                              <option value="男">男</option>
+                              <option value="女">女</option>
+                            </select>
+                          </div>
+                          <div className="form-group">
+                            <label className="form-label">部屋番号</label>
+                            <input
+                              type="text"
+                              name="roomNumber"
+                              value={formData.roomNumber}
+                              onChange={handleInputChange}
+                              className="form-input"
+                            />
+                          </div>
+                        </div>
                         <div className="form-group">
                           <label className="form-label">住所</label>
                           <input
@@ -3859,16 +3943,28 @@
                             placeholder="特記事項やメモを入力してください..."
                           />
                         </div>
-                        <div className="form-group">
-                          <label className="form-label">申込日 *</label>
-                          <input
-                            type="date"
-                            name="applicationDate"
-                            value={formData.applicationDate}
-                            onChange={handleInputChange}
-                            className="form-input"
-                            required
-                          />
+                        <div className="form-row">
+                          <div className="form-group">
+                            <label className="form-label">申込日 *</label>
+                            <input
+                              type="date"
+                              name="applicationDate"
+                              value={formData.applicationDate}
+                              onChange={handleInputChange}
+                              className="form-input"
+                              required
+                            />
+                          </div>
+                          <div className="form-group">
+                            <label className="form-label">入居日</label>
+                            <input
+                              type="date"
+                              name="moveInDate"
+                              value={formData.moveInDate}
+                              onChange={handleInputChange}
+                              className="form-input"
+                            />
+                          </div>
                         </div>
                       </form>
                     </div>

--- a/scripts/add-gender.js
+++ b/scripts/add-gender.js
@@ -1,0 +1,27 @@
+const sqlite3 = require('sqlite3').verbose();
+const path = require('path');
+
+const DB_PATH = path.join(__dirname, '../database/shinchoku.db');
+
+const db = new sqlite3.Database(DB_PATH, (err) => {
+  if (err) {
+    console.error('データベース接続エラー:', err);
+    process.exit(1);
+  }
+});
+
+console.log('genderカラムを追加します...');
+
+db.run("ALTER TABLE applicants ADD COLUMN gender TEXT", (err) => {
+  if (err) {
+    if (err.message.includes('duplicate column name')) {
+      console.log('✅ genderカラムは既に存在します');
+    } else {
+      console.error('❌ エラー:', err);
+    }
+  } else {
+    console.log('✅ genderカラムを追加しました');
+  }
+
+  db.close();
+});

--- a/scripts/check-db.js
+++ b/scripts/check-db.js
@@ -1,0 +1,27 @@
+const sqlite3 = require('sqlite3').verbose();
+const path = require('path');
+
+const DB_PATH = path.join(__dirname, '../database/shinchoku.db');
+
+const db = new sqlite3.Database(DB_PATH, (err) => {
+  if (err) {
+    console.error('データベース接続エラー:', err);
+    process.exit(1);
+  }
+});
+
+// applicantsテーブルの構造を確認
+db.all("PRAGMA table_info(applicants)", (err, rows) => {
+  if (err) {
+    console.error('エラー:', err);
+    db.close();
+    process.exit(1);
+  }
+
+  console.log('\n📋 applicantsテーブルの構造:\n');
+  rows.forEach(row => {
+    console.log(`  ${row.name.padEnd(20)} ${row.type.padEnd(10)} ${row.notnull ? 'NOT NULL' : ''} ${row.dflt_value ? `DEFAULT ${row.dflt_value}` : ''}`);
+  });
+
+  db.close();
+});

--- a/scripts/run-migration.js
+++ b/scripts/run-migration.js
@@ -1,0 +1,64 @@
+const sqlite3 = require('sqlite3').verbose();
+const path = require('path');
+const fs = require('fs');
+
+const DB_PATH = path.join(__dirname, '../database/shinchoku.db');
+const MIGRATION_PATH = path.join(__dirname, '../database/migration-add-registry-fields.sql');
+
+// マイグレーションを実行
+const db = new sqlite3.Database(DB_PATH, (err) => {
+  if (err) {
+    console.error('データベース接続エラー:', err);
+    process.exit(1);
+  }
+});
+
+// マイグレーションSQLを読み込み
+const migrationSQL = fs.readFileSync(MIGRATION_PATH, 'utf8');
+
+// セミコロンで分割して各ステートメントを実行
+const statements = migrationSQL
+  .split(';')
+  .map(s => s.trim())
+  .filter(s => s.length > 0 && !s.startsWith('--'));
+
+console.log('マイグレーションを開始します...');
+
+// 各ステートメントを順番に実行
+const executeStatements = async () => {
+  for (const statement of statements) {
+    try {
+      await new Promise((resolve, reject) => {
+        db.run(statement, (err) => {
+          if (err) {
+            // カラムがすでに存在する場合は無視
+            if (err.message.includes('duplicate column name')) {
+              console.log(`⚠️  カラムは既に存在します: ${statement.substring(0, 50)}...`);
+              resolve();
+            } else {
+              reject(err);
+            }
+          } else {
+            console.log(`✅ 実行成功: ${statement.substring(0, 50)}...`);
+            resolve();
+          }
+        });
+      });
+    } catch (error) {
+      console.error(`❌ エラー: ${error.message}`);
+      console.error(`   SQL: ${statement}`);
+      process.exit(1);
+    }
+  }
+};
+
+executeStatements()
+  .then(() => {
+    console.log('\n✨ マイグレーション完了！');
+    db.close();
+  })
+  .catch((error) => {
+    console.error('マイグレーションエラー:', error);
+    db.close();
+    process.exit(1);
+  });


### PR DESCRIPTION
- データベースに新規フィールドを追加（性別、部屋番号、入居日、市区町村）
- 住所から市区町村を自動抽出する機能を実装
- 統計データ計算APIエンドポイントを作成（/api/statistics）
- 新規登録・編集フォームに新フィールドを追加
- 詳細ページに新フィールドの表示を追加
- APIクライアントとSupabaseクライアントを更新

統計APIは以下のデータを提供：
- 基本統計（総数、入居済、平均年齢、女性比率）
- 市区町村別分布
- 要介護度別分布
- ステータス別分布
- 年齢分布
- 性別分布
- 月別申込数・入居数

次のステップ：ダッシュボードUIとグラフ機能の実装