### PR TITLE
入居日設定機能の根本的な不具合を修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -1251,7 +1251,22 @@
           const loadApplicants = async () => {
             try {
               const data = await apiClient.getApplicants();
-              setApplicants(data);
+              // snake_case から camelCase への変換
+              const camelCaseData = data.map(app => ({
+                ...app,
+                careLevel: app.care_level || app.careLevel,
+                applicationDate: app.application_date || app.applicationDate,
+                kpRelationship: app.kp_relationship || app.kpRelationship,
+                kpContact: app.kp_contact || app.kpContact,
+                kpAddress: app.kp_address || app.kpAddress,
+                careManager: app.care_manager || app.careManager,
+                careManagerName: app.care_manager_name || app.careManagerName,
+                cmContact: app.cm_contact || app.cmContact,
+                givenName: app.given_name || app.givenName,
+                roomNumber: app.room_number || app.roomNumber,
+                moveInDate: app.move_in_date || app.moveInDate
+              }));
+              setApplicants(camelCaseData);
             } catch (error) {
               console.error('Failed to load applicants:', error);
             }

--- a/server.js
+++ b/server.js
@@ -99,9 +99,9 @@ app.get('/api/applicants', authenticateToken, async (req, res) => {
     const applicants = await db.all(`
       SELECT id, surname, given_name, age, care_level, address, kp, kp_relationship,
              kp_contact, kp_address, care_manager, care_manager_name, cm_contact,
-             assignee, notes, status, application_date,
+             assignee, notes, status, application_date, gender, room_number, move_in_date, municipality,
              (surname || '　' || given_name) as name
-      FROM applicants 
+      FROM applicants
       ORDER BY application_date DESC
     `);
 


### PR DESCRIPTION
## 問題の根本原因

**原因1：サーバー側でmove_in_dateカラムを返していなかった**
- `GET /api/applicants`エンドポイントのSELECT句に`move_in_date`が含まれていなかった
- そのため、データベースに保存されても次回の取得時に日付が含まれず、UIに反映されなかった

**原因2：データ構造の不一致（snake_case vs camelCase）**
- データベース：snake_case（例：move_in_date、care_level）
- フロントエンド：camelCase（例：moveInDate、careLevel）
- データ変換処理が存在せず、フロントエンドでデータにアクセスできなかった

## 修正内容

### 1. サーバー側の修正（server.js）
- `GET /api/applicants`エンドポイントのSELECT句に以下を追加：
  - `move_in_date`（入居日）
  - `gender`（性別）
  - `room_number`（部屋番号）
  - `municipality`（市区町村）

### 2. フロントエンド側の修正（index.html）
- `loadApplicants`関数にsnake_caseからcamelCaseへの変換処理を追加
- データベースから取得したsnake_caseのデータを、フロントエンドで使用するcamelCaseに変換
- 既存データとの互換性を保つため、両方の形式をサポート（`app.move_in_date || app.moveInDate`）

## 変換されるフィールド
- care_level → careLevel
- application_date → applicationDate
- kp_relationship → kpRelationship
- kp_contact → kpContact
- kp_address → kpAddress
- care_manager → careManager
- care_manager_name → careManagerName
- cm_contact → cmContact
- given_name → givenName
- room_number → roomNumber
- move_in_date → moveInDate

## 動作フロー（修正後）
1. ユーザーがダッシュボードで入居日欄をクリック
2. date inputが表示され、カレンダーから日付を選択
3. onChange→handleMoveInDateUpdate→apiClient.updateApplicant
4. サーバーでmove_in_dateカラムに保存
5. loadApplicants()でデータを再取得
6. サーバーからmove_in_dateを含むデータを取得
7. フロントエンドでsnake_case→camelCaseに変換
8. applicant.moveInDateとして正しくUIに表示

## 影響範囲
- server.js: SELECT句の修正（+4フィールド）
- index.html: loadApplicants関数にデータ変換処理を追加（+17行）
- データベーススキーマ：変更なし
- UI・デザイン：変更なし
- 既存機能：影響なし

## テスト確認項目
- ✅ 入居日を選択すると正しく保存される
- ✅ 保存後、UIに即座に反映される
- ✅ ページを再読み込みしても入居日が保持される
- ✅ 申込一覧の表示に影響がない
- ✅ 他のフィールド（性別、部屋番号など）も正しく表示される