### PR TITLE
セキュリティ強化：セッションタイムアウト、パスワード変更、HTTPS強制

### DIFF
--- a/index.html
+++ b/index.html
@@ -1125,6 +1125,14 @@
           const [savingStatus, setSavingStatus] = React.useState('idle'); // idle | saving | saved | error
           const saveTimerRef = React.useRef(null);
 
+          // パスワード変更管理
+          const [showPasswordModal, setShowPasswordModal] = React.useState(false);
+          const [passwordForm, setPasswordForm] = React.useState({
+            currentPassword: '',
+            newPassword: '',
+            confirmPassword: ''
+          });
+
           const [formData, setFormData] = React.useState({
             surname: '',
             givenName: '',
@@ -1166,6 +1174,37 @@
               }
             }
           }, []);
+
+          // 自動ログアウト機能（30分無操作でログアウト）
+          React.useEffect(() => {
+            if (!isLoggedIn) return;
+
+            const AUTO_LOGOUT_TIME = 30 * 60 * 1000; // 30分
+            let logoutTimer = null;
+
+            const resetLogoutTimer = () => {
+              if (logoutTimer) clearTimeout(logoutTimer);
+
+              logoutTimer = setTimeout(() => {
+                handleLogout();
+                alert('セッションがタイムアウトしました。再度ログインしてください。');
+              }, AUTO_LOGOUT_TIME);
+            };
+
+            resetLogoutTimer();
+
+            const events = ['mousedown', 'keydown', 'scroll', 'touchstart'];
+            events.forEach(event => {
+              document.addEventListener(event, resetLogoutTimer);
+            });
+
+            return () => {
+              events.forEach(event => {
+                document.removeEventListener(event, resetLogoutTimer);
+              });
+              if (logoutTimer) clearTimeout(logoutTimer);
+            };
+          }, [isLoggedIn]);
 
           // リアルタイム監視の設定
           React.useEffect(() => {
@@ -1831,6 +1870,41 @@
             apiClient.disconnectSocket();
             setCurrentView('list');
             setApplicants([]);
+          };
+
+          const handlePasswordChange = async (e) => {
+            e.preventDefault();
+
+            if (passwordForm.newPassword !== passwordForm.confirmPassword) {
+              alert('新しいパスワードが一致しません');
+              return;
+            }
+
+            try {
+              const response = await fetch('/api/change-password', {
+                method: 'POST',
+                headers: {
+                  'Content-Type': 'application/json',
+                  'Authorization': `Bearer ${localStorage.getItem('authToken')}`
+                },
+                body: JSON.stringify({
+                  currentPassword: passwordForm.currentPassword,
+                  newPassword: passwordForm.newPassword
+                })
+              });
+
+              if (response.ok) {
+                alert('パスワードを変更しました');
+                setShowPasswordModal(false);
+                setPasswordForm({ currentPassword: '', newPassword: '', confirmPassword: '' });
+              } else {
+                const error = await response.json();
+                alert(error.error || 'パスワード変更に失敗しました');
+              }
+            } catch (error) {
+              console.error('パスワード変更エラー:', error);
+              alert('パスワード変更に失敗しました');
+            }
           };
 
           const handleLoginInputChange = (e) => {
@@ -3404,9 +3478,14 @@
                         <div className="user-greeting">
                           こんにちは、{currentUser?.name}さん
                         </div>
-                        <button onClick={handleLogout} className="logout-btn">
-                          ログアウト
-                        </button>
+                        <div style={{display: 'flex', gap: '8px', justifyContent: 'flex-end'}}>
+                          <button onClick={() => setShowPasswordModal(true)} className="btn btn-secondary" style={{fontSize: '13px', padding: '6px 12px'}}>
+                            パスワード変更
+                          </button>
+                          <button onClick={handleLogout} className="logout-btn">
+                            ログアウト
+                          </button>
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -4159,6 +4238,64 @@
                         削除
                       </button>
                     </div>
+                  </div>
+                </div>
+              )}
+
+              {showPasswordModal && (
+                <div className="modal-overlay" onClick={() => setShowPasswordModal(false)}>
+                  <div className="modal" onClick={(e) => e.stopPropagation()} style={{maxWidth: '500px'}}>
+                    <div className="modal-header">
+                      <h3 className="modal-title">パスワード変更</h3>
+                      <button className="modal-close" onClick={() => setShowPasswordModal(false)}>×</button>
+                    </div>
+                    <form onSubmit={handlePasswordChange}>
+                      <div className="modal-body">
+                        <div className="form-group">
+                          <label htmlFor="currentPassword" className="form-label">現在のパスワード</label>
+                          <input
+                            type="password"
+                            id="currentPassword"
+                            className="form-input"
+                            value={passwordForm.currentPassword}
+                            onChange={(e) => setPasswordForm({...passwordForm, currentPassword: e.target.value})}
+                            required
+                          />
+                        </div>
+                        <div className="form-group">
+                          <label htmlFor="newPassword" className="form-label">新しいパスワード（8文字以上）</label>
+                          <input
+                            type="password"
+                            id="newPassword"
+                            className="form-input"
+                            value={passwordForm.newPassword}
+                            onChange={(e) => setPasswordForm({...passwordForm, newPassword: e.target.value})}
+                            required
+                            minLength="8"
+                          />
+                        </div>
+                        <div className="form-group">
+                          <label htmlFor="confirmPassword" className="form-label">新しいパスワード（確認）</label>
+                          <input
+                            type="password"
+                            id="confirmPassword"
+                            className="form-input"
+                            value={passwordForm.confirmPassword}
+                            onChange={(e) => setPasswordForm({...passwordForm, confirmPassword: e.target.value})}
+                            required
+                            minLength="8"
+                          />
+                        </div>
+                      </div>
+                      <div className="modal-footer">
+                        <button type="button" className="btn btn-secondary" onClick={() => setShowPasswordModal(false)}>
+                          キャンセル
+                        </button>
+                        <button type="submit" className="btn btn-primary">
+                          変更
+                        </button>
+                      </div>
+                    </form>
                   </div>
                 </div>
               )}

--- a/server.js
+++ b/server.js
@@ -26,6 +26,17 @@ const PORT = process.env.PORT || 3001;
 const JWT_SECRET = process.env.JWT_SECRET || 'shinchoku-secret-key-2024';
 
 // ミドルウェア
+// 本番環境でHTTPSを強制
+if (process.env.NODE_ENV === 'production') {
+  app.use((req, res, next) => {
+    if (req.header('x-forwarded-proto') !== 'https') {
+      res.redirect(`https://${req.header('host')}${req.url}`);
+    } else {
+      next();
+    }
+  });
+}
+
 app.use(cors());
 app.use(bodyParser.json());
 app.use(express.static(path.join(__dirname)));
@@ -74,7 +85,7 @@ app.post('/api/auth/login', async (req, res) => {
     const token = jwt.sign(
       { id: user.id, username: user.username, name: user.name },
       JWT_SECRET,
-      { expiresIn: '24h' }
+      { expiresIn: '2h' }
     );
 
     res.json({
@@ -663,6 +674,44 @@ io.on('connection', (socket) => {
   socket.on('disconnect', () => {
     console.log('クライアントが切断されました:', socket.id);
   });
+});
+
+// パスワード変更エンドポイント
+app.post('/api/change-password', authenticateToken, async (req, res) => {
+  try {
+    const { currentPassword, newPassword } = req.body;
+    const userId = req.user.id;
+
+    // 現在のパスワード確認
+    const user = await db.get('SELECT * FROM users WHERE id = ?', [userId]);
+
+    if (!user) {
+      return res.status(404).json({ error: 'ユーザーが見つかりません' });
+    }
+
+    const isValid = await bcrypt.compare(currentPassword, user.password_hash);
+
+    if (!isValid) {
+      return res.status(401).json({ error: '現在のパスワードが正しくありません' });
+    }
+
+    // パスワード強度チェック
+    if (!newPassword || newPassword.length < 8) {
+      return res.status(400).json({ error: 'パスワードは8文字以上である必要があります' });
+    }
+
+    // 新しいパスワードをハッシュ化して保存
+    const newHash = await bcrypt.hash(newPassword, 10);
+    await db.run(
+      'UPDATE users SET password_hash = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?',
+      [newHash, userId]
+    );
+
+    res.json({ message: 'パスワードを変更しました' });
+  } catch (error) {
+    console.error('パスワード変更エラー:', error);
+    res.status(500).json({ error: 'パスワード変更に失敗しました' });
+  }
 });
 
 // サーバー起動


### PR DESCRIPTION
## 実装内容

### 1. セッションタイムアウトの短縮
- **server.js**: JWT有効期限を24時間→2時間に変更
- **index.html**: 30分無操作で自動ログアウト機能を追加
  - マウス/キーボード/スクロール/タッチ操作を監視
  - イベントリスナーの適切なクリーンアップ実装

### 2. パスワード変更機能
- **server.js**: 新しいエンドポイント POST /api/change-password を追加
  - 現在のパスワード確認
  - パスワード強度チェック（8文字以上）
  - bcryptによるハッシュ化
  - 適切なエラーハンドリング
- **index.html**: パスワード変更UI実装
  - ダッシュボードにパスワード変更ボタン追加
  - モーダルフォーム（現在/新規/確認パスワード入力）
  - パスワード一致確認
  - 既存デザインと統一されたUI

### 3. HTTPS強制リダイレクト
- **server.js**: 本番環境でHTTPSを強制するミドルウェア追加
  - NODE_ENV=production時のみ有効
  - x-forwarded-protoヘッダーチェック
  - ローカル開発環境には影響なし

## 既存機能への影響
- 既存のUI/デザイン/レイアウトは維持
- 既存の認証ロジックは変更なし
- 既存のエンドポイントは変更なし
- 新機能は追加のみ、既存コードへの影響最小限