### PR TITLE
パスワード変更ボタンの遅延バグを修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -1872,11 +1872,23 @@
             setApplicants([]);
           };
 
+          const handlePasswordButtonClick = (e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            setShowPasswordModal(true);
+          };
+
           const handlePasswordChange = async (e) => {
             e.preventDefault();
+            e.stopPropagation();
 
             if (passwordForm.newPassword !== passwordForm.confirmPassword) {
               alert('新しいパスワードが一致しません');
+              return;
+            }
+
+            if (passwordForm.newPassword.length < 8) {
+              alert('パスワードは8文字以上である必要があります');
               return;
             }
 
@@ -3479,7 +3491,7 @@
                           こんにちは、{currentUser?.name}さん
                         </div>
                         <div style={{display: 'flex', gap: '8px', justifyContent: 'flex-end'}}>
-                          <button onClick={() => setShowPasswordModal(true)} className="btn btn-secondary" style={{fontSize: '13px', padding: '6px 12px'}}>
+                          <button onClick={handlePasswordButtonClick} type="button" className="btn btn-secondary" style={{fontSize: '13px', padding: '6px 12px'}}>
                             パスワード変更
                           </button>
                           <button onClick={handleLogout} className="logout-btn">
@@ -4243,13 +4255,28 @@
               )}
 
               {showPasswordModal && (
-                <div className="modal-overlay" onClick={() => setShowPasswordModal(false)}>
+                <div className="modal-overlay" onClick={(e) => {
+                  e.stopPropagation();
+                  setShowPasswordModal(false);
+                }}>
                   <div className="modal" onClick={(e) => e.stopPropagation()} style={{maxWidth: '500px'}}>
                     <div className="modal-header">
                       <h3 className="modal-title">パスワード変更</h3>
-                      <button className="modal-close" onClick={() => setShowPasswordModal(false)}>×</button>
+                      <button
+                        className="modal-close"
+                        type="button"
+                        onClick={(e) => {
+                          e.preventDefault();
+                          e.stopPropagation();
+                          setShowPasswordModal(false);
+                        }}
+                      >×</button>
                     </div>
-                    <form onSubmit={handlePasswordChange}>
+                    <form onSubmit={(e) => {
+                      e.preventDefault();
+                      e.stopPropagation();
+                      handlePasswordChange(e);
+                    }}>
                       <div className="modal-body">
                         <div className="form-group">
                           <label htmlFor="currentPassword" className="form-label">現在のパスワード</label>
@@ -4260,6 +4287,7 @@
                             value={passwordForm.currentPassword}
                             onChange={(e) => setPasswordForm({...passwordForm, currentPassword: e.target.value})}
                             required
+                            autoComplete="current-password"
                           />
                         </div>
                         <div className="form-group">
@@ -4272,6 +4300,7 @@
                             onChange={(e) => setPasswordForm({...passwordForm, newPassword: e.target.value})}
                             required
                             minLength="8"
+                            autoComplete="new-password"
                           />
                         </div>
                         <div className="form-group">
@@ -4284,11 +4313,20 @@
                             onChange={(e) => setPasswordForm({...passwordForm, confirmPassword: e.target.value})}
                             required
                             minLength="8"
+                            autoComplete="new-password"
                           />
                         </div>
                       </div>
                       <div className="modal-footer">
-                        <button type="button" className="btn btn-secondary" onClick={() => setShowPasswordModal(false)}>
+                        <button
+                          type="button"
+                          className="btn btn-secondary"
+                          onClick={(e) => {
+                            e.preventDefault();
+                            e.stopPropagation();
+                            setShowPasswordModal(false);
+                          }}
+                        >
                           キャンセル
                         </button>
                         <button type="submit" className="btn btn-primary">


### PR DESCRIPTION
## 問題
パスワード変更ボタンをクリックしても即座に反応せず、次の別のボタンを
クリックしたときにモーダルが表示される遅延が発生していた

## 原因
- ボタンに type 属性が明示されていなかった
- イベントの伝播制御が不十分だった
- preventDefault/stopPropagation の実装が不足していた

## 修正内容

### 1. イベントハンドラーの追加
- handlePasswordButtonClick 関数を新規追加
- e.preventDefault() と e.stopPropagation() を実装

### 2. ボタンの修正
- パスワード変更ボタンに type="button" を明示的に指定
- onClick を handlePasswordButtonClick に変更

### 3. モーダルのイベント伝播制御を強化
- モーダル背景クリックで確実に閉じるよう改善
- すべてのボタンに適切な type 属性を追加
- form の onSubmit で handlePasswordChange を呼び出し
- すべてのイベントハンドラーで preventDefault/stopPropagation を実装

### 4. handlePasswordChange 関数の改善
- e.stopPropagation() を追加
- パスワード長チェック（8文字以上）を追加

### 5. アクセシビリティの改善
- すべての password 入力に autoComplete 属性を追加

## 既存機能への影響
- 既存の UI/デザイン/レイアウトは維持
- 他のモーダル機能には一切影響なし
- パスワード変更機能のみを修正